### PR TITLE
Set tsconfig paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.ts text
+*.js text
+*.json text
+*.md text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/main.ts
+++ b/main.ts
@@ -1,17 +1,17 @@
 import {Plugin} from 'obsidian';
-import {HorizontalRuleProcessor} from "./src/drawSteelAdmonition/horizontalRuleProcessor";
-import {InitiativeProcessor} from "./src/drawSteelAdmonition/initiativeProcessor";
-import {NegotiationTrackerProcessor} from "./src/drawSteelAdmonition/negotiation/NegotiationTrackerProcessor";
-import {StatblockProcessor} from "./src/drawSteelAdmonition/statblock/StatblockProcessor";
-import {MyPluginSettingTab} from "./src/views/SettingsTab";
-import {DEFAULT_SETTINGS, DSESettings} from "./src/model/Settings";
-import {CompendiumDownloader} from "./src/utils/CompendiumDownloader";
-import {AbilityProcessor} from "./src/drawSteelAdmonition/ability/AbilityProcessor";
-import {StaminaBarProcessor} from "./src/drawSteelAdmonition/StaminaBar/StaminaBarProcessor";
-import {CounterProcessor} from "./src/drawSteelAdmonition/Counter/CounterProcessor";
-import {CharacteristicsProcessor} from "./src/drawSteelAdmonition/Characteristics/CharacteristicsProcessor";
-import {SkillsProcessor} from "./src/drawSteelAdmonition/Skills/SkillsProcessor";
-import {ValuesRowProcessor} from "./src/drawSteelAdmonition/ValuesRow/ValuesRowProcessor";
+import {HorizontalRuleProcessor} from "@drawSteelAdmonition/horizontalRuleProcessor";
+import {InitiativeProcessor} from "@drawSteelAdmonition/initiativeProcessor";
+import {NegotiationTrackerProcessor} from "@drawSteelAdmonition/negotiation/NegotiationTrackerProcessor";
+import {StatblockProcessor} from "@drawSteelAdmonition/statblock/StatblockProcessor";
+import {MyPluginSettingTab} from "@views/SettingsTab";
+import {DEFAULT_SETTINGS, DSESettings} from "@model/Settings";
+import {CompendiumDownloader} from "@utils/CompendiumDownloader";
+import {AbilityProcessor} from "@drawSteelAdmonition/ability/AbilityProcessor";
+import {StaminaBarProcessor} from "@drawSteelAdmonition/StaminaBar/StaminaBarProcessor";
+import {CounterProcessor} from "@drawSteelAdmonition/Counter/CounterProcessor";
+import {CharacteristicsProcessor} from "@drawSteelAdmonition/Characteristics/CharacteristicsProcessor";
+import {SkillsProcessor} from "@drawSteelAdmonition/Skills/SkillsProcessor";
+import {ValuesRowProcessor} from "@drawSteelAdmonition/ValuesRow/ValuesRowProcessor";
 
 export default class DrawSteelAdmonitionPlugin extends Plugin {
     settings: DSESettings;

--- a/src/drawSteelAdmonition/Characteristics/CharacteristicsProcessor.ts
+++ b/src/drawSteelAdmonition/Characteristics/CharacteristicsProcessor.ts
@@ -1,6 +1,6 @@
 import {Plugin, MarkdownPostProcessorContext} from "obsidian";
-import {CharacteristicsView} from "./CharacteristicsView";
-import {Characteristics} from "../../model/Characteristics";
+import {CharacteristicsView} from "@drawSteelAdmonition/Characteristics/CharacteristicsView";
+import {Characteristics} from "@model/Characteristics";
 
 export class CharacteristicsProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/Characteristics/CharacteristicsView.ts
+++ b/src/drawSteelAdmonition/Characteristics/CharacteristicsView.ts
@@ -1,5 +1,5 @@
 import { Component, MarkdownPostProcessorContext, Plugin } from "obsidian";
-import { Characteristics } from "../../model/Characteristics";
+import { Characteristics } from "@model/Characteristics";
 
 export class CharacteristicsView {
 	private plugin: Plugin;

--- a/src/drawSteelAdmonition/Counter/CounterProcessor.ts
+++ b/src/drawSteelAdmonition/Counter/CounterProcessor.ts
@@ -1,6 +1,6 @@
 import {Plugin, MarkdownPostProcessorContext} from "obsidian";
-import {CounterView} from "./CounterView";
-import {Counter} from "../../model/Counter";
+import {CounterView} from "@drawSteelAdmonition/Counter/CounterView";
+import {Counter} from "@model/Counter";
 
 export class CounterProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/Counter/CounterView.ts
+++ b/src/drawSteelAdmonition/Counter/CounterView.ts
@@ -1,6 +1,6 @@
 import { Component, MarkdownPostProcessorContext, Plugin, setIcon } from "obsidian";
-import { Counter } from "../../model/Counter";
-import { CodeBlocks } from "../../utils/CodeBlocks";
+import { Counter } from "@model/Counter";
+import { CodeBlocks } from "@utils/CodeBlocks";
 
 export class CounterView {
 	private plugin: Plugin;

--- a/src/drawSteelAdmonition/Skills/SkillsProcessor.ts
+++ b/src/drawSteelAdmonition/Skills/SkillsProcessor.ts
@@ -1,6 +1,6 @@
 import {Plugin, MarkdownPostProcessorContext} from "obsidian";
-import {SkillsView} from "./SkillsView";
-import {Skills} from "../../model/Skills";
+import {SkillsView} from "@drawSteelAdmonition/Skills/SkillsView";
+import {Skills} from "@model/Skills";
 
 export class SkillsProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/Skills/SkillsView.ts
+++ b/src/drawSteelAdmonition/Skills/SkillsView.ts
@@ -1,6 +1,6 @@
 import { Component, MarkdownPostProcessorContext, Plugin } from "obsidian";
-import { Skills, CustomSkill } from "../../model/Skills";
-import { SKILL_DATA } from "../../utils/SkillsData";
+import { Skills, CustomSkill } from "@model/Skills";
+import { SKILL_DATA } from "@utils/SkillsData";
 
 export class SkillsView {
 	private plugin: Plugin;

--- a/src/drawSteelAdmonition/StaminaBar/StaminaBarProcessor.ts
+++ b/src/drawSteelAdmonition/StaminaBar/StaminaBarProcessor.ts
@@ -1,6 +1,6 @@
 import {Plugin, MarkdownPostProcessorContext} from "obsidian";
-import {StaminaBarView} from "./StaminaBarView";
-import {StaminaBar} from "../../model/StaminaBar";
+import {StaminaBarView} from "@drawSteelAdmonition/StaminaBar/StaminaBarView";
+import {StaminaBar} from "@model/StaminaBar";
 
 export class StaminaBarProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/StaminaBar/StaminaBarView.ts
+++ b/src/drawSteelAdmonition/StaminaBar/StaminaBarView.ts
@@ -1,7 +1,7 @@
 import {Component, MarkdownPostProcessorContext, MarkdownRenderer, Plugin} from "obsidian";
-import {StaminaBar} from "../../model/StaminaBar";
-import {StaminaEditModal} from "../../views/StaminaEditModal";
-import {CodeBlocks} from "../../utils/CodeBlocks";
+import {StaminaBar} from "@model/StaminaBar";
+import {StaminaEditModal} from "@views/StaminaEditModal";
+import {CodeBlocks} from "@utils/CodeBlocks";
 
 export class StaminaBarView {
 	private plugin: Plugin;

--- a/src/drawSteelAdmonition/ValuesRow/ValuesRowProcessor.ts
+++ b/src/drawSteelAdmonition/ValuesRow/ValuesRowProcessor.ts
@@ -1,6 +1,6 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { ValuesRowView } from "./ValuesRowView";
-import { KeyValuePairs } from "../../model/KeyValuePairs";
+import { ValuesRowView } from "@drawSteelAdmonition/ValuesRow/ValuesRowView";
+import { KeyValuePairs } from "@model/KeyValuePairs";
 
 export class ValuesRowProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/ValuesRow/ValuesRowView.ts
+++ b/src/drawSteelAdmonition/ValuesRow/ValuesRowView.ts
@@ -1,5 +1,5 @@
 import {MarkdownPostProcessorContext, Plugin} from "obsidian";
-import {KeyValuePairs, KVPair} from "../../model/KeyValuePairs";
+import {KeyValuePairs, KVPair} from "@model/KeyValuePairs";
 
 export class ValuesRowView {
 	private plugin: Plugin;

--- a/src/drawSteelAdmonition/ability/AbilityProcessor.ts
+++ b/src/drawSteelAdmonition/ability/AbilityProcessor.ts
@@ -1,6 +1,6 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { AbilityView } from "./AbilityView";
-import { AbilityConfig } from "../../model/AbilityConfig";
+import { AbilityView } from "@drawSteelAdmonition/ability/AbilityView";
+import { AbilityConfig } from "@model/AbilityConfig";
 
 export class AbilityProcessor {
 	plugin: Plugin;

--- a/src/drawSteelAdmonition/ability/AbilityView.ts
+++ b/src/drawSteelAdmonition/ability/AbilityView.ts
@@ -1,8 +1,8 @@
 import { Component, MarkdownPostProcessorContext, MarkdownRenderer, Plugin } from "obsidian";
-import { AbilityConfig } from "../../model/AbilityConfig";
+import { AbilityConfig } from "@model/AbilityConfig";
 import { MundaneEffect, PowerRollEffect } from "steel-compendium-sdk";
-import { PowerRollEffectView } from "./PowerRollEffectView";
-import { MundaneEffectView } from "./MundaneEffectView";
+import { PowerRollEffectView } from "@drawSteelAdmonition/ability/PowerRollEffectView";
+import { MundaneEffectView } from "@drawSteelAdmonition/ability/MundaneEffectView";
 
 export class AbilityView {
     private plugin: Plugin;

--- a/src/drawSteelAdmonition/initiativeProcessor.ts
+++ b/src/drawSteelAdmonition/initiativeProcessor.ts
@@ -1,9 +1,9 @@
 import { App, MarkdownPostProcessorContext, setIcon } from "obsidian";
-import { StaminaEditModal } from "../views/StaminaEditModal";
-import { ConditionManager } from "../utils/Conditions";
-import { AddConditionsModal } from "../views/ConditionSelectModal";
-import { DEFAULT_IMAGE_PATH, Images } from "../utils/Images";
-import { CodeBlocks } from "../utils/CodeBlocks";
+import { StaminaEditModal } from "@views/StaminaEditModal";
+import { ConditionManager } from "@utils/Conditions";
+import { AddConditionsModal } from "@views/ConditionSelectModal";
+import { DEFAULT_IMAGE_PATH, Images } from "@utils/Images";
+import { CodeBlocks } from "@utils/CodeBlocks";
 import {
 	Condition,
 	Creature,
@@ -14,9 +14,9 @@ import {
 	parseEncounterData,
 	resetEncounter,
 } from "./EncounterData";
-import { ResetEncounterModal } from "../views/ResetEncounterModal";
-import {MinionStaminaPoolModal} from "../views/MinionStaminaPoolModal";
-import {StaminaBar} from "../model/StaminaBar";
+import { ResetEncounterModal } from "@views/ResetEncounterModal";
+import {MinionStaminaPoolModal} from "@views/MinionStaminaPoolModal";
+import {StaminaBar} from "@model/StaminaBar";
 
 export class InitiativeProcessor {
 	private app: App;

--- a/src/drawSteelAdmonition/negotiation/ArgumentView.ts
+++ b/src/drawSteelAdmonition/negotiation/ArgumentView.ts
@@ -1,10 +1,8 @@
 import { App, MarkdownPostProcessorContext, setIcon, setTooltip } from "obsidian";
-import { NegotiationData } from "../../model/NegotiationData";
-import { CodeBlocks } from "../../utils/CodeBlocks";
-import { AbilityProcessor } from "../ability/abilityProcessor";
-import {ArgumentPowerRoll, ArgumentResult} from "../../model/ArgumentPowerRolls";
-import { labeledIcon } from "../../utils/common";
-import {AbilityView} from "../ability/AbilityView";
+import { NegotiationData } from "@model/NegotiationData";
+import { CodeBlocks } from "@utils/CodeBlocks";
+import {ArgumentPowerRoll, ArgumentResult} from "@model/ArgumentPowerRolls";
+import { labeledIcon } from "@utils/common";
 import {PowerRollEffectView} from "../ability/PowerRollEffectView";
 
 export class ArgumentView {

--- a/src/drawSteelAdmonition/negotiation/LearnMoreView.ts
+++ b/src/drawSteelAdmonition/negotiation/LearnMoreView.ts
@@ -1,9 +1,7 @@
 import {App, MarkdownPostProcessorContext, setTooltip} from "obsidian";
-import {NegotiationData} from "../../model/NegotiationData";
-import {PowerRollTiers} from "../../model/powerRoll";
-import {AbilityProcessor} from "../ability/abilityProcessor";
-import {AbilityView} from "../ability/AbilityView";
-import {PowerRollEffectView} from "../ability/PowerRollEffectView";
+import {NegotiationData} from "@model/NegotiationData";
+import {PowerRollTiers} from "@model/powerRoll";
+import {PowerRollEffectView} from "@drawSteelAdmonition/ability/PowerRollEffectView";
 
 export class LearnMoreView {
 	private app: App;

--- a/src/drawSteelAdmonition/negotiation/MotivationsPitfallsView.ts
+++ b/src/drawSteelAdmonition/negotiation/MotivationsPitfallsView.ts
@@ -1,6 +1,6 @@
 import {App, MarkdownPostProcessorContext} from "obsidian";
-import {NegotiationData} from "../../model/NegotiationData";
-import {CodeBlocks} from "../../utils/CodeBlocks";
+import {NegotiationData} from "@model/NegotiationData";
+import {CodeBlocks} from "@utils/CodeBlocks";
 
 export class MotivationsPitfallsView {
 	private app: App;

--- a/src/drawSteelAdmonition/negotiation/NegotiationTrackerProcessor.ts
+++ b/src/drawSteelAdmonition/negotiation/NegotiationTrackerProcessor.ts
@@ -1,11 +1,11 @@
 import {App, MarkdownPostProcessorContext, Menu, Notice, setIcon} from "obsidian";
-import {NegotiationData, parseNegotiationData} from "../../model/NegotiationData";
-import {PatienceInterestView} from "./PatienceInterestView";
-import {MotivationsPitfallsView} from "./MotivationsPitfallsView";
-import {ArgumentView} from "./ArgumentView";
-import {LearnMoreView} from "./LearnMoreView";
-import {CodeBlocks} from "../../utils/CodeBlocks";
-import {labeledIcon} from "../../utils/common";
+import {CurrentArgument, NegotiationData, parseNegotiationData} from "@model/NegotiationData";
+import {PatienceInterestView} from "@drawSteelAdmonition/negotiation/PatienceInterestView";
+import {MotivationsPitfallsView} from "@drawSteelAdmonition/negotiation/MotivationsPitfallsView";
+import {ArgumentView} from "@drawSteelAdmonition/negotiation/ArgumentView";
+import {LearnMoreView} from "@drawSteelAdmonition/negotiation/LearnMoreView";
+import {CodeBlocks} from "@utils/CodeBlocks";
+import {labeledIcon} from "@utils/common";
 
 export class NegotiationTrackerProcessor {
 	private app: App;

--- a/src/drawSteelAdmonition/negotiation/PatienceInterestView.ts
+++ b/src/drawSteelAdmonition/negotiation/PatienceInterestView.ts
@@ -1,6 +1,6 @@
 import {App, MarkdownPostProcessorContext} from "obsidian";
-import {NegotiationData} from "../../model/NegotiationData";
-import {CodeBlocks} from "../../utils/CodeBlocks";
+import {NegotiationData} from "@model/NegotiationData";
+import {CodeBlocks} from "@utils/CodeBlocks";
 
 export class PatienceInterestView {
 	private app: App;

--- a/src/drawSteelAdmonition/statblock/AbilitiesView.ts
+++ b/src/drawSteelAdmonition/statblock/AbilitiesView.ts
@@ -1,6 +1,6 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { AbilityView } from "../ability/AbilityView";
-import { AbilityConfig } from "../../model/AbilityConfig";
+import { AbilityView } from "@drawSteelAdmonition/ability/AbilityView";
+import { AbilityConfig } from "@model/AbilityConfig";
 
 export class AbilitiesView {
     private plugin: Plugin;

--- a/src/drawSteelAdmonition/statblock/HeaderView.ts
+++ b/src/drawSteelAdmonition/statblock/HeaderView.ts
@@ -1,5 +1,5 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { StatblockConfig } from "../../model/StatblockConfig";
+import { StatblockConfig } from "@model/StatblockConfig";
 
 export class HeaderView {
     private plugin: Plugin;

--- a/src/drawSteelAdmonition/statblock/StatblockProcessor.ts
+++ b/src/drawSteelAdmonition/statblock/StatblockProcessor.ts
@@ -1,10 +1,10 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { StatblockConfig } from "../../model/StatblockConfig";
-import { HeaderView } from "./HeaderView";
-import { StatsView } from "./StatsView";
-import { AbilitiesView } from "./AbilitiesView";
-import { TraitsView } from "./TraitsView";
-import { HorizontalRuleProcessor } from "../horizontalRuleProcessor";
+import { StatblockConfig } from "@model/StatblockConfig";
+import { HeaderView } from "@drawSteelAdmonition/statblock/HeaderView";
+import { StatsView } from "@drawSteelAdmonition/statblock/StatsView";
+import { AbilitiesView } from "@drawSteelAdmonition/statblock/AbilitiesView";
+import { TraitsView } from "@drawSteelAdmonition/statblock/TraitsView";
+import { HorizontalRuleProcessor } from "@drawSteelAdmonition/horizontalRuleProcessor";
 import { AbilityConfig } from "src/model/AbilityConfig";
 import { Ability } from "steel-compendium-sdk";
 

--- a/src/drawSteelAdmonition/statblock/StatsView.ts
+++ b/src/drawSteelAdmonition/statblock/StatsView.ts
@@ -1,6 +1,5 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { StatblockConfig } from "../../model/StatblockConfig";
-import {HorizontalRuleProcessor} from "../horizontalRuleProcessor";
+import { StatblockConfig } from "@model/StatblockConfig";
 
 export class StatsView {
     private plugin: Plugin;

--- a/src/drawSteelAdmonition/statblock/TraitsView.ts
+++ b/src/drawSteelAdmonition/statblock/TraitsView.ts
@@ -1,8 +1,8 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
-import { StatblockConfig } from "../../model/StatblockConfig";
+import { StatblockConfig } from "@model/StatblockConfig";
 import { MundaneEffect, PowerRollEffect, Trait } from "steel-compendium-sdk";
-import { PowerRollEffectView } from "../ability/PowerRollEffectView";
-import { MundaneEffectView } from "../ability/MundaneEffectView";
+import { PowerRollEffectView } from "@drawSteelAdmonition/ability/PowerRollEffectView";
+import { MundaneEffectView } from "@drawSteelAdmonition/ability/MundaneEffectView";
 
 export class TraitsView {
     private plugin: Plugin;

--- a/src/model/ArgumentPowerRolls.ts
+++ b/src/model/ArgumentPowerRolls.ts
@@ -1,4 +1,4 @@
-import {PowerRollTiers} from "./powerRoll";
+import {PowerRollTiers} from "@model/powerRoll";
 
 export class ArgumentPowerRoll {
 	public t1: ArgumentResult;

--- a/src/model/Effect.ts
+++ b/src/model/Effect.ts
@@ -1,6 +1,6 @@
 import {MarkdownPostProcessorContext, Plugin} from "obsidian";
-import {PowerRollEffectView} from "../drawSteelAdmonition/ability/PowerRollEffectView";
-import {MundaneEffectView} from "../drawSteelAdmonition/ability/MundaneEffectView";
+import {PowerRollEffectView} from "@drawSteelAdmonition/ability/PowerRollEffectView";
+import {MundaneEffectView} from "@drawSteelAdmonition/ability/MundaneEffectView";
 
 export abstract class Effect {
 	static parseAll(data: any): Effect[] {

--- a/src/model/StaminaBar.ts
+++ b/src/model/StaminaBar.ts
@@ -1,5 +1,5 @@
 import {parseYaml} from "obsidian";
-import {Creature, CreatureInstance, Hero} from "../drawSteelAdmonition/EncounterData";
+import {Creature, CreatureInstance, Hero} from "@drawSteelAdmonition/EncounterData";
 
 export class StaminaBar {
 	max_stamina: number;

--- a/src/utils/CodeBlocks.ts
+++ b/src/utils/CodeBlocks.ts
@@ -1,7 +1,7 @@
 import {App, MarkdownPostProcessorContext, TFile, stringifyYaml, ItemView, EditorSelection} from "obsidian";
-import {EncounterData} from "../drawSteelAdmonition/EncounterData";
-import {NegotiationData} from "../model/NegotiationData";
-import {StaminaBar} from "../model/StaminaBar";
+import {EncounterData} from "@drawSteelAdmonition/EncounterData";
+import {NegotiationData} from "@model/NegotiationData";
+import {StaminaBar} from "@model/StaminaBar";
 
 export class CodeBlocks {
 	static async updateInitiativeTracker(app: App, data: EncounterData, ctx: MarkdownPostProcessorContext): Promise<void> {

--- a/src/utils/CompendiumDownloader.ts
+++ b/src/utils/CompendiumDownloader.ts
@@ -1,5 +1,5 @@
 import {App, Notice, request, requestUrl, RequestUrlParam} from "obsidian";
-import JSZip from "jszip";
+import * as JSZip from "jszip";
 
 export class CompendiumDownloader {
 	private app: App;

--- a/src/views/ConditionSelectModal.ts
+++ b/src/views/ConditionSelectModal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, setIcon } from 'obsidian';
-import { Condition, CreatureInstance, Hero } from "../drawSteelAdmonition/EncounterData";
-import { ConditionManager, ConditionConfig } from "../utils/Conditions";
-import { CustomizeConditionModal } from "./CustomizeConditionModal";
+import { Condition, CreatureInstance, Hero } from "@drawSteelAdmonition/EncounterData";
+import { ConditionManager, ConditionConfig } from "@utils/Conditions";
+import { CustomizeConditionModal } from "@views/CustomizeConditionModal";
 
 export class AddConditionsModal extends Modal {
 	private character: Hero | CreatureInstance;

--- a/src/views/CustomizeConditionModal.ts
+++ b/src/views/CustomizeConditionModal.ts
@@ -1,6 +1,6 @@
 import {App, Modal, setIcon} from "obsidian";
-import {Condition} from "../drawSteelAdmonition/EncounterData";
-import {ConditionConfig} from "../utils/Conditions";
+import {Condition} from "@drawSteelAdmonition/EncounterData";
+import {ConditionConfig} from "@utils/Conditions";
 
 export class CustomizeConditionModal extends Modal {
     private conditionData: Condition;

--- a/src/views/SettingsTab.ts
+++ b/src/views/SettingsTab.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
-import DrawSteelAdmonitionPlugin from "../../main";
-import {CompendiumDownloader} from "../utils/CompendiumDownloader";
+import DrawSteelAdmonitionPlugin from "main";
+import {CompendiumDownloader} from "@utils/CompendiumDownloader";
 
 export class MyPluginSettingTab extends PluginSettingTab {
 	plugin: DrawSteelAdmonitionPlugin;

--- a/src/views/StaminaEditModal.ts
+++ b/src/views/StaminaEditModal.ts
@@ -1,5 +1,5 @@
 import { App, Modal, setIcon } from "obsidian";
-import {StaminaBar} from "../model/StaminaBar";
+import {StaminaBar} from "@model/StaminaBar";
 
 export class StaminaEditModal extends Modal {
 	private staminaBar: StaminaBar;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "paths": {
+        "@/*": ["src/*"],
+        "@model/*": ["src/model/*"],
+        "@utils/*": ["src/utils/*"],
+        "@views/*": ["src/views/*"],
+        "@drawSteelAdmonition/*": ["src/drawSteelAdmonition/*"],
+    },
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
@@ -10,13 +17,13 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",
       "ES6",
       "ES7"
-    ]
+    ] 
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
This is a small readibility configuration that allows us to use a few @paths to give us simpler to read import statements.

Example:
`import {Characteristics} from "../../model/Characteristics";`
becomes
`import {Characteristics} from "@model/Characteristics";`

No more relative path operators.