### PR TITLE
Add .repo-docs documentation

### DIFF
--- a/.repo-docs/architecture.md
+++ b/.repo-docs/architecture.md
@@ -1,0 +1,204 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Architecture
+
+## System Overview
+
+The plugin follows a processor-based architecture where each Draw Steel element type has a dedicated processor that parses YAML input and renders DOM output. Vue 3 components handle interactive elements; plain TypeScript DOM manipulation handles simpler ones.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Obsidian App                          │
+│                                                         │
+│  ┌──────────────┐    ┌───────────────────────────────┐  │
+│  │  Markdown     │    │  Draw Steel Elements Plugin    │  │
+│  │  Note with    │───>│                               │  │
+│  │  ```ds-*      │    │  main.ts (Plugin entry)       │  │
+│  │  blocks       │    │    │                           │  │
+│  └──────────────┘    │    ▼                           │  │
+│                      │  RegisterElements.ts            │  │
+│                      │    │                           │  │
+│                      │    ├── FeatureProcessor         │  │
+│                      │    ├── StatblockProcessor       │  │
+│                      │    ├── InitiativeProcessor      │  │
+│                      │    ├── NegotiationProcessor     │  │
+│                      │    ├── genericComponentProcessor │  │
+│                      │    │   ├── HorizontalRule.vue   │  │
+│                      │    │   ├── SkillList.vue        │  │
+│                      │    │   └── StaminaBar.vue       │  │
+│                      │    ├── CounterProcessor         │  │
+│                      │    ├── CharacteristicsProcessor │  │
+│                      │    ├── FeatureblockProcessor    │  │
+│                      │    └── ValuesRowProcessor       │  │
+│                      │                               │  │
+│                      │  Utils:                        │  │
+│                      │    ├── ReferenceResolver        │  │
+│                      │    ├── JsonSchemaValidator      │  │
+│                      │    └── CompendiumDownloader     │  │
+│                      └───────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### Plugin Entry (`main.ts`)
+
+- **Responsibility:** Loads settings, initializes schema registry, registers code block processors, adds compendium download command.
+- **Depends on:** `RegisterElements`, `JsonSchemaValidator`, `Settings`, `CompendiumDownloader`
+- **Depended on by:** Obsidian app (plugin lifecycle)
+
+### Element Registration (`src/utils/RegisterElements.ts`)
+
+- **Responsibility:** Maps code block language tags (e.g., `ds-ft`, `ds-feature`) to their processors. Each element type gets multiple aliases.
+- **Depends on:** All processor classes, Vue components, model classes
+- **Depended on by:** `main.ts`
+
+### Processors (`src/drawSteelAdmonition/`)
+
+Each element type has a processor with this pattern:
+
+| Processor | Directory | Rendering approach |
+|-----------|-----------|-------------------|
+| FeatureProcessor | `Features/` | DOM manipulation via View classes |
+| FeatureblockProcessor | `featureblock/` | DOM manipulation via View classes |
+| StatblockProcessor | `statblock/` | DOM manipulation via View classes |
+| InitiativeProcessor | `initiativeProcessor.ts` | DOM manipulation with interactive state |
+| NegotiationTrackerProcessor | `negotiation/` | DOM manipulation with interactive state |
+| CounterProcessor | `Counter/` | DOM manipulation |
+| CharacteristicsProcessor | `Characteristics/` | DOM manipulation |
+| ValuesRowProcessor | `ValuesRow/` | DOM manipulation |
+| genericComponentProcessor | `(utils/)` | Vue 3 component mounting |
+
+Two rendering strategies exist:
+1. **DOM-based processors**: Parse YAML, create HTML elements via Obsidian's `createEl` API. Used for most elements.
+2. **Vue-based processors**: Use `genericComponentProcessor` which mounts a Vue 3 app into the code block container. Used for SkillList, StaminaBar, HorizontalRule.
+
+### Vue Components (`src/drawSteelComponents/`)
+
+- **Responsibility:** Interactive UI components rendered via Vue 3 Composition API.
+- **Pattern:** Receive parsed model data as props, use Obsidian plugin/app/context via Vue's `provide`/`inject`.
+- **Key components:** `StaminaBar.vue` (health tracking with edit modal), `SkillList.vue` (collapsible skill groups), `HorizontalRule.vue` (styled divider).
+
+### Models (`src/model/`)
+
+- **Responsibility:** Define TypeScript types and provide `parseYaml(source)` static methods that convert raw YAML strings into typed objects.
+- **Pattern:** Each model class has a static `parseYaml()` method using Obsidian's `parseYaml` function. Some models use the SDK (`steel-compendium-sdk`) for parsing.
+- **Schemas:** `src/model/schemas/` contains YAML-format JSON Schemas validated by AJV at runtime.
+
+### Utilities (`src/utils/`)
+
+| Utility | Purpose |
+|---------|---------|
+| `ComponentProcessor.ts` | Generic Vue component mounting into Obsidian code blocks |
+| `ReferenceResolver.ts` | Resolves `@path` and `[[wikilink]]` references to content in other vault notes |
+| `JsonSchemaValidator.ts` | AJV-based validation with YAML schema support, singleton registry pattern |
+| `CompendiumDownloader.ts` | Downloads and extracts GitHub release zips into the Obsidian vault |
+| `RegisterElements.ts` | Code block processor registration |
+| `Conditions.ts` | Draw Steel condition definitions |
+| `SkillsData.ts` | Draw Steel skill definitions |
+| `Images.ts` | Image handling utilities |
+| `CodeBlocks.ts` | Code block parsing helpers |
+| `ModalProcessor.ts` | Modal dialog utilities |
+| `common.ts` | Shared utility functions |
+
+### Views (`src/views/`)
+
+- **Responsibility:** Obsidian modal dialogs for interactive elements.
+- **Key modals:** `ConditionSelectModal` (pick conditions), `CustomizeConditionModal` (modify condition details), `MinionStaminaPoolModal` (manage minion shared stamina), `StaminaEditModal` (edit stamina values), `ResetEncounterModal` (reset initiative tracker), `SettingsTab` (plugin settings UI).
+
+## Data Flow
+
+### Code Block Rendering
+
+```
+User writes ```ds-feature YAML``` in a note
+        │
+        ▼
+Obsidian detects registered language tag
+        │
+        ▼
+FeatureProcessor.handler(source, el, ctx) called
+        │
+        ▼
+YAML source parsed (Obsidian parseYaml or model.parseYaml)
+        │
+        ├── If references found (@path / [[link]])
+        │   └── ReferenceResolver fetches content from other notes
+        │
+        ▼
+Optional: Schema validation (AJV)
+        │
+        ▼
+DOM elements created and appended to container (el)
+   OR Vue app mounted into container
+        │
+        ▼
+Rendered element visible in Reading mode
+```
+
+### Compendium Download
+
+```
+User triggers "Download Compendium" command
+        │
+        ▼
+CompendiumDownloader fetches GitHub release API
+        │
+        ▼
+Downloads repo.zip asset
+        │
+        ▼
+Deletes existing compendium directory
+        │
+        ▼
+Extracts zip contents into vault (batch of 20 files)
+```
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Two rendering strategies (DOM + Vue) | Vue was introduced gradually (v3.3.0). Simpler elements use direct DOM; interactive elements with state use Vue. Migration is ongoing. |
+| Multiple code block aliases per element | Convenience for users: `ds-ft`, `ds-feat`, `ds-feature` all work. Short aliases for frequent use, full names for readability. |
+| esbuild with Vue plugin | Fast builds. Vue SFC compilation via `unplugin-vue/esbuild`. YAML loaded as raw strings via custom loader plugin. |
+| Singleton AJV schema registry | Schemas registered once at plugin load, reused across validations. Fresh instances created per validation to avoid compiled schema conflicts. |
+| Reading mode only | Obsidian's Live Preview mode uses CodeMirror 6 with a different rendering pipeline. Supporting it requires significant additional work. |
+| SDK as devDependency | `steel-compendium-sdk` is bundled at build time by esbuild, not needed at runtime as a separate package. |
+
+## Dependencies
+
+| Package | Why |
+|---------|-----|
+| `vue` (3.x) | Composition API components for interactive elements |
+| `ajv` / `ajv-errors` / `ajv-keywords` | Runtime YAML schema validation for element inputs |
+| `obsidian` (dev) | Obsidian Plugin API types and runtime APIs |
+| `steel-compendium-sdk` (dev) | Draw Steel data model parsing (bundled at build time) |
+| `esbuild` (dev) | Fast bundler producing `main.js` |
+| `unplugin-vue` (dev) | Vue SFC compilation for esbuild |
+| `vue-tsc` (dev) | Vue-aware TypeScript type checking |
+| `jszip` / `jszip-utils` (dev) | Zip extraction for compendium downloads (bundled) |
+| `jest` / `ts-jest` (dev) | Test framework (configured but no tests yet) |
+
+## Extension Points
+
+- **Adding a new element type:**
+  1. Create a processor class in `src/drawSteelAdmonition/<ElementName>/`
+  2. Create a model in `src/model/` with a `parseYaml()` method
+  3. Register code block languages in `src/utils/RegisterElements.ts`
+  4. Add CSS in `styles-source.css`
+  5. Add docs in `docs/`
+
+- **Adding a Vue-based element:** Use `genericComponentProcessor` with your Vue component and model class. See `SkillList` or `StaminaBar` for examples.
+
+- **Adding a schema:** Create a YAML schema in `src/model/schemas/`, register it in `main.ts` `initializeSchemas()`.
+
+## Constraints
+
+- Must work in Obsidian's sandboxed plugin environment (no direct filesystem access, use Vault API).
+- Output must be CJS format (`format: "cjs"`) for Obsidian compatibility.
+- Target ES2018 for broad Obsidian version support.
+- `obsidian`, `electron`, and CodeMirror packages are external (provided by the host app).

--- a/.repo-docs/architecture.md
+++ b/.repo-docs/architecture.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Architecture
 
 ## System Overview

--- a/.repo-docs/ci-cd.md
+++ b/.repo-docs/ci-cd.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # CI/CD
 
 ## Pipeline Overview

--- a/.repo-docs/ci-cd.md
+++ b/.repo-docs/ci-cd.md
@@ -1,0 +1,101 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# CI/CD
+
+## Pipeline Overview
+
+| Trigger | What it does | Config file |
+|---------|-------------|-------------|
+| Push to `main` or `master` | Builds and deploys MkDocs documentation to gh-pages | `.github/workflows/ci.yml` |
+
+The CI pipeline handles **documentation deployment only**. Plugin builds and releases are done locally via the justfile.
+
+## Build Process
+
+Local build commands:
+
+```sh
+# Development (watch mode, sourcemaps, no minification)
+npm run dev
+
+# Production (type check + minified bundle, no sourcemaps)
+npm run build
+
+# Production without type check
+npm run build-no-check
+```
+
+esbuild produces a single `main.js` (CJS format) and copies Vue-generated CSS to `styles.css`.
+
+## Build Artifacts
+
+| Artifact | Description |
+|----------|-------------|
+| `main.js` | Bundled plugin code (CJS). Uploaded to GitHub releases. |
+| `styles.css` | Plugin styles (copied from `main.css` by esbuild plugin). Uploaded to GitHub releases. |
+| `manifest.json` | Obsidian plugin manifest with version info. Uploaded to GitHub releases. |
+
+## Branch Strategy
+
+- **`main`** -- primary branch, release-ready code
+- **`develop`** -- integration branch (exists as remote)
+- **Feature branches** -- named by feature (e.g., `initiative`, `featureblocks`, `negotiation`)
+- **`gh-pages`** -- auto-deployed docs site
+
+## Commit Conventions
+
+Commits use informal descriptive messages. No strict conventional commits format is enforced. Examples from history:
+
+```
+Removes legacy link
+Initial pass on splitting up css
+Prepares for release '5.1.1'
+Corrects issue where double-clicking on an Element in reading mode will open edit mode
+```
+
+## Release Process
+
+### Using the justfile (recommended)
+
+```sh
+just release <version>
+```
+
+This recipe:
+1. Updates `version` in `manifest.json` and `package.json`
+2. Runs `npm run build-no-check` (production build)
+3. Commits all changes
+4. Pushes to origin
+5. Creates a GitHub release with tag `<version>`, uploading `main.js`, `manifest.json`, `styles.css`
+
+### Manual release
+
+1. Update version in `manifest.json` and `package.json` (semver without `v` prefix)
+2. Update `CHANGELOG.md`
+3. Run `npm run build`
+4. Create a GitHub release:
+   - Tag matches the version in `manifest.json`
+   - Upload `main.js`, `manifest.json`, `styles.css` as binary attachments
+
+### Versioning
+
+- Semver without `v` prefix (e.g., `5.1.1`, not `v5.1.1`)
+- Tag name = release name = version string
+- Obsidian uses `manifest.json` version to check for updates
+
+## Environments
+
+| Environment | Description |
+|-------------|-------------|
+| Local dev | `npm run dev` in a symlinked Obsidian vault plugin directory |
+| Docs site | https://steelcompendium.io (MkDocs Material on gh-pages) |
+| Distribution | GitHub Releases (Obsidian community plugin registry fetches from here) |
+
+## Secrets and Configuration
+
+- No secrets required for CI (MkDocs deployment uses `GITHUB_TOKEN` from Actions)
+- The `CompendiumDownloader` supports an optional GitHub token for authenticated API requests but does not require one

--- a/.repo-docs/conventions.md
+++ b/.repo-docs/conventions.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Conventions
 
 ## File and Directory Naming

--- a/.repo-docs/conventions.md
+++ b/.repo-docs/conventions.md
@@ -1,0 +1,68 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Conventions
+
+## File and Directory Naming
+
+- **Directories:** PascalCase for feature modules (`Features/`, `StaminaBar/`, `Counter/`), camelCase for some (`featureblock/`, `negotiation/`, `statblock/`)
+- **TypeScript files:** PascalCase for classes and components (`FeatureProcessor.ts`, `StaminaBarView.ts`), camelCase for non-class modules (`common.ts`, `initiativeProcessor.ts`)
+- **Vue files:** PascalCase (`HorizontalRule.vue`, `StaminaBar.vue`, `CollapsibleHeading.vue`)
+- **Schema files:** PascalCase with `Schema` suffix (`ComponentWrapperSchema.yaml`, `SkillsSchema.yaml`)
+
+## Code Style
+
+- **Formatter:** None configured (no Prettier)
+- **Linter:** ESLint with `@typescript-eslint`
+- **Config:** `.eslintrc` (JSON format)
+- **Key rules:**
+  - No unused variables (error, but unused function args allowed)
+  - `@ts-comment` directives allowed
+  - Empty functions allowed
+  - No prototype builtins check disabled
+
+- **EditorConfig:** `.editorconfig`
+  - Indent: 4 spaces
+  - Line endings: CRLF
+  - Charset: UTF-8
+  - Final newline: yes
+
+## TypeScript Configuration
+
+- **Path aliases:** `@/*` -> `src/*`, `@model/*` -> `src/model/*`, `@utils/*` -> `src/utils/*`, `@views/*` -> `src/views/*`, `@drawSteelAdmonition/*`, `@drawSteelComponents/*`
+- **Strict null checks:** enabled
+- **No implicit any:** enabled
+- **Module:** ESNext, target ES6
+- **Vue:** `vue-tsc` used for type checking Vue SFCs
+
+## Vue Conventions
+
+- **API:** Composition API only (`__VUE_OPTIONS_API__` set to `false`)
+- **Dependency injection:** Obsidian plugin, app, and context provided via Vue's `provide`/`inject`
+- **Component props:** Model data passed as props from `genericComponentProcessor`
+
+## Naming Conventions
+
+- **Classes:** PascalCase (`FeatureProcessor`, `ReferenceResolver`, `DrawSteelAdmonitionPlugin`)
+- **Interfaces:** PascalCase, descriptive (`DSESettings`, `ValidationResult`, `ValidationError`)
+- **Methods:** camelCase (`postProcess`, `resolveReferences`, `downloadAndExtractRelease`)
+- **Constants:** UPPER_SNAKE_CASE (`DEFAULT_SETTINGS`)
+- **Code block tags:** lowercase with hyphens, `ds-` prefix (`ds-feature`, `ds-stamina-bar`)
+- **CSS classes:** lowercase with hyphens, `ds-` prefix (`ds-container`, `ds-multiline`, `ds-vue-wrapper`)
+
+## Commit Messages
+
+Based on observed patterns, commits use short descriptive sentences without conventional commit prefixes:
+
+```
+Removes legacy link
+Initial pass on splitting up css
+Corrects issue where double-clicking on an Element in reading mode will open edit mode
+Checkpoint: basic functionality for initiative tracker
+Featureblocks are feature complete
+```
+
+Release commits follow the pattern: `Prepares for release '<version>'`

--- a/.repo-docs/decisions/2024-08-18-esbuild-bundler.md
+++ b/.repo-docs/decisions/2024-08-18-esbuild-bundler.md
@@ -1,0 +1,45 @@
+# Use esbuild as Bundler
+
+**Date:** 2024-08-18
+**Status:** accepted
+
+## Context
+
+The plugin needs to produce a single `main.js` file (CJS format) that Obsidian
+can load. A bundler is required to compile TypeScript, bundle dependencies, and
+produce the final output.
+
+## Options Considered
+
+### esbuild
+- Pros: Extremely fast builds, simple config, good plugin ecosystem, handles CJS output natively, Obsidian sample plugin uses it
+- Cons: Less mature plugin ecosystem than Webpack, no built-in HMR
+
+### Webpack
+- Pros: Mature ecosystem, handles complex configurations, widely used
+- Cons: Slow builds, complex configuration, overkill for a plugin
+
+### Rollup
+- Pros: Good tree-shaking, clean output
+- Cons: Slower than esbuild, more configuration needed for CJS + TypeScript + Vue
+
+## Decision
+
+Used esbuild from the initial commit. Configuration lives in
+`esbuild.config.mjs` with custom plugins for Vue SFC compilation
+(`unplugin-vue/esbuild`) and raw YAML file loading.
+
+Key config: CJS output format, ES2018 target, externals for `obsidian`,
+`electron`, and CodeMirror packages (provided by the Obsidian host).
+
+## Consequences
+
+- Sub-second builds in development with watch mode
+- Custom esbuild plugin needed for copying CSS output (`main.css` -> `styles.css`)
+- Vue support added later via `unplugin-vue/esbuild` without changing bundlers
+- Production builds run in ~1 second
+
+## Outcome
+
+esbuild has been excellent. Build speed is never a bottleneck. The Vue plugin
+integration was seamless. No reason to consider switching.

--- a/.repo-docs/decisions/2024-08-18-reading-mode-only.md
+++ b/.repo-docs/decisions/2024-08-18-reading-mode-only.md
@@ -1,0 +1,41 @@
+# Reading Mode Only -- No Live Preview
+
+**Date:** 2024-08-18
+**Status:** accepted
+
+## Context
+
+Obsidian has two rendering modes: Reading mode (renders full HTML from
+markdown) and Live Preview (uses CodeMirror 6 editor with inline rendering).
+The plugin needs to decide which modes to support.
+
+## Options Considered
+
+### Support Reading mode only
+- Pros: Simpler implementation, full DOM control via `MarkdownPostProcessorContext`, faster development
+- Cons: Users must switch to Reading mode to see rendered elements, poor UX for users who prefer Live Preview
+
+### Support both Reading and Live Preview
+- Pros: Better user experience, works in the mode users already use
+- Cons: Live Preview uses CodeMirror 6 with a completely different rendering pipeline (EditorView decorations), doubles implementation complexity, CM6 API is less documented
+
+## Decision
+
+Support Reading mode only. The plugin registers code block processors via
+Obsidian's `registerMarkdownCodeBlockProcessor` API, which only fires in
+Reading mode.
+
+## Consequences
+
+- Plugin README prominently warns about this limitation
+- Users must switch to Reading mode to see rendered elements
+- Implementation is straightforward -- one rendering pipeline to maintain
+- Live Preview support is listed as future work but hasn't been prioritized
+
+## Outcome
+
+This has been the primary user-facing limitation. However, the complexity
+savings are significant -- maintaining one rendering pipeline for the number
+of element types in this plugin (11+) is already substantial. Live Preview
+support would roughly double the rendering code. The tradeoff remains
+acceptable given the project's scope and contributor count.

--- a/.repo-docs/decisions/2024-10-17-power-roll-to-feature.md
+++ b/.repo-docs/decisions/2024-10-17-power-roll-to-feature.md
@@ -1,0 +1,43 @@
+# Replace Power Roll with Feature Element
+
+**Date:** 2024-10-17
+**Status:** accepted
+
+## Context
+
+The original element was called "Power Roll" (`ds-power-roll`) and had a flat
+YAML structure. As the plugin matured, it needed to support more than just
+power rolls -- tests, resistance rolls, abilities with multiple effects, and
+tiered outcomes. The flat structure couldn't express ordered lists of effects.
+
+## Options Considered
+
+### Rename to "Feature" with structured effects
+- Pros: More general name covers all use cases (abilities, tests, resistance rolls), `effects` array allows ordered content, backwards-compatible aliases possible
+- Cons: Breaking YAML format change, existing users must update their notes
+
+### Extend Power Roll with optional fields
+- Pros: No breaking change, gradual migration
+- Cons: Name becomes misleading (not all features are power rolls), flat structure becomes unwieldy with many optional fields
+
+## Decision
+
+Replaced the Power Roll element with the Feature element (v2.0.0). The YAML
+format changed from flat fields to a structured `effects` array. Code block
+tags changed to `ds-feature` / `ds-feat` / `ds-ft`. The Statblock element
+inherited the same structured effects format.
+
+## Consequences
+
+- Breaking change for all existing users (v2.0.0)
+- More expressive YAML format for complex abilities
+- The "Feature" name is Draw Steel-native (matches the game's terminology)
+- Statblock abilities automatically benefit from the same format
+- Old `ds-power-roll` tag was removed
+
+## Outcome
+
+The Feature element format has proven flexible enough for all ability types
+encountered so far. The structured effects array was the right design -- it
+cleanly handles abilities with multiple tiers, tests, and resistance rolls.
+No regrets on the breaking change.

--- a/.repo-docs/decisions/2025-08-19-adopt-sdk.md
+++ b/.repo-docs/decisions/2025-08-19-adopt-sdk.md
@@ -1,0 +1,44 @@
+# Adopt steel-compendium-sdk for Data Parsing
+
+**Date:** 2025-08-19
+**Status:** accepted
+
+## Context
+
+The plugin originally had its own YAML parsing logic for Draw Steel data
+structures (statblocks, abilities, etc.). As the data model grew more complex
+and was shared across multiple repos in the Steel Compendium project, parsing
+logic needed to be centralized.
+
+## Options Considered
+
+### Use steel-compendium-sdk (data-sdk-npm)
+- Pros: Single source of truth for data models, shared across repos, TypeScript types included, maintained separately
+- Cons: External dependency, version bumps can be breaking, bundled at build time increases bundle size
+
+### Keep parsing logic in-plugin
+- Pros: No external dependency, full control, simpler build
+- Cons: Duplicated logic across repos, schema changes require updating multiple codebases, no shared types
+
+## Decision
+
+Adopted `steel-compendium-sdk` as a devDependency (bundled by esbuild at build
+time). Model classes in `src/model/` use the SDK's parsing functions. The SDK
+version is pinned in `package.json`.
+
+Initially adopted at v0.x (v3.0.0 of this plugin). Later upgraded to v2.1.5
+in a breaking change (v4.0.0 of this plugin) that required users to
+re-download the compendium.
+
+## Consequences
+
+- Breaking SDK version bumps require a major version bump of this plugin
+- Users must re-download the compendium when SDK schema changes are breaking
+- The compendium download directory is deleted and recreated (users warned not to store homebrew there)
+- Centralized data model maintenance across the Steel Compendium project
+
+## Outcome
+
+The SDK has been the right call. Schema changes are managed in one place.
+The v0-to-v2.1.5 upgrade (plugin v4.0.0) was painful for users but necessary.
+The "re-download compendium" requirement is well-documented.

--- a/.repo-docs/decisions/2025-08-22-adopt-vue-3.md
+++ b/.repo-docs/decisions/2025-08-22-adopt-vue-3.md
@@ -1,7 +1,7 @@
 # Adopt Vue 3 for Interactive Components
 
 **Date:** 2025-08-22
-**Status:** accepted
+**Status:** superseded
 
 ## Context
 

--- a/.repo-docs/decisions/2025-08-22-adopt-vue-3.md
+++ b/.repo-docs/decisions/2025-08-22-adopt-vue-3.md
@@ -1,0 +1,50 @@
+# Adopt Vue 3 for Interactive Components
+
+**Date:** 2025-08-22
+**Status:** accepted
+
+## Context
+
+The plugin had grown to include several interactive elements (stamina bars,
+skill lists) that required reactive state management. Building these with raw
+DOM manipulation was becoming verbose and error-prone. A community contributor
+(seedback, PR #65) proposed adding Vue 3.
+
+## Options Considered
+
+### Vue 3 Composition API
+- Pros: Reactive state management, SFC components, small bundle size, Composition API is ergonomic for plugin-sized components
+- Cons: Adds build complexity (needs `unplugin-vue` for esbuild), increases bundle size, two rendering approaches to maintain
+
+### Continue with raw DOM manipulation
+- Pros: No new dependency, simpler build, consistent approach across all elements
+- Cons: Increasingly verbose for interactive elements, no reactivity system, harder to maintain state-heavy components
+
+### Lit / Web Components
+- Pros: Standards-based, small, no build plugin needed
+- Cons: Less ecosystem support, fewer contributors familiar with it, Obsidian community uses Vue/React more commonly
+
+## Decision
+
+Adopted Vue 3 with Composition API. Introduced gradually -- new interactive
+components use Vue, existing DOM-based processors remain as-is. The
+`genericComponentProcessor` utility handles mounting Vue apps into Obsidian code
+block containers.
+
+The `__VUE_OPTIONS_API__` flag is set to `false` to tree-shake the Options API
+and reduce bundle size.
+
+## Consequences
+
+- Two rendering strategies coexist (DOM-based and Vue-based)
+- Build config requires `unplugin-vue/esbuild` plugin
+- Vue SFCs need `vue-tsc` for type checking (standard `tsc` doesn't understand `.vue` files)
+- Interactive components (StaminaBar, SkillList) are significantly easier to build and maintain
+- Opened the door for community contributions using a familiar framework
+
+## Outcome
+
+Vue adoption has worked well. StaminaBar and SkillList Vue components are
+cleaner than their DOM equivalents would have been. The two-strategy approach
+hasn't caused confusion -- the pattern for each is clear. No plans to migrate
+all existing DOM processors to Vue; they work fine as-is.

--- a/.repo-docs/decisions/2026-04-06-revert-vue-3-adoption.md
+++ b/.repo-docs/decisions/2026-04-06-revert-vue-3-adoption.md
@@ -1,0 +1,41 @@
+# Revert Vue 3 Adoption
+
+**Date:** 2026-04-06
+**Status:** accepted
+
+## Context
+
+The 2025-08-22 decision adopted Vue 3 for interactive components. After living
+with the two-rendering-strategy approach, the added complexity — build tooling
+(`unplugin-vue`, `vue-tsc`), larger bundle, two mental models for contributors —
+is not justified by the benefits. The juice isn't worth the squeeze.
+
+## Options Considered
+
+### Keep Vue 3
+- Pros: Already integrated, reactive state management, familiar to some contributors
+- Cons: Extra build complexity, increased bundle size, two rendering strategies to maintain, `vue-tsc` needed alongside `tsc`
+
+### Remove Vue 3, return to DOM manipulation only
+- Pros: Single rendering strategy, simpler build pipeline, smaller bundle, one less dependency, lower contributor onboarding cost
+- Cons: Slightly more verbose for interactive elements, lose reactivity system
+
+## Decision
+
+Remove Vue 3 and return to DOM-based rendering for all elements. Existing Vue
+components (StaminaBar, SkillList) will be rewritten as DOM-based processors
+using the same pattern as the rest of the codebase.
+
+This supersedes [2025-08-22-adopt-vue-3](2025-08-22-adopt-vue-3.md).
+
+## Consequences
+
+- Single, consistent rendering strategy across the entire plugin
+- Simpler build configuration (remove `unplugin-vue/esbuild`)
+- Standard `tsc` sufficient for type checking (no `vue-tsc` needed)
+- Smaller bundle size
+- Interactive components will need rewriting, but the scope is small
+
+## Outcome
+
+_To be filled in after migration is complete._

--- a/.repo-docs/decisions/README.md
+++ b/.repo-docs/decisions/README.md
@@ -79,7 +79,8 @@ What actually happened? Lessons learned? Would you choose the same again?
 
 | Date | Decision | Status |
 |------|----------|--------|
-| 2024-03-01 | [Adopt Vue 3 for interactive components](2024-03-01-adopt-vue-3.md) | accepted |
+| 2026-04-06 | [Revert Vue 3 adoption](2026-04-06-revert-vue-3-adoption.md) | accepted |
+| 2024-03-01 | [Adopt Vue 3 for interactive components](2024-03-01-adopt-vue-3.md) | superseded |
 | 2024-01-15 | [Adopt steel-compendium-sdk for data parsing](2024-01-15-adopt-sdk.md) | accepted |
 | 2023-10-01 | [Replace Power Roll with Feature element](2023-10-01-power-roll-to-feature.md) | accepted |
 | 2023-06-01 | [Use esbuild as bundler](2023-06-01-esbuild-bundler.md) | accepted |

--- a/.repo-docs/decisions/README.md
+++ b/.repo-docs/decisions/README.md
@@ -1,0 +1,86 @@
+# Decision Log
+
+## Why We Log Decisions
+
+Context doesn't survive in memory. Six months from now, nobody will remember why
+we chose esbuild over Vite, or why Power Roll was renamed to Feature. Decision
+records prevent relitigating settled choices and give new contributors the "why"
+behind the codebase.
+
+## What to Log
+
+Every decision, regardless of size:
+
+- Library and framework choices
+- Data format or schema changes
+- Naming changes (element types, YAML fields)
+- Rejected approaches and why they were rejected
+- Conventions established (naming, file organization)
+- Reverted experiments and what was learned
+- Breaking changes and migration strategies
+
+## How to Create a Record
+
+1. Copy the template below into a new file
+2. Name it `YYYY-MM-DD-short-description.md` (files sort chronologically)
+3. Fill in all sections. Leave **Outcome** blank if the decision is recent.
+4. Set the status field
+
+Multiple decisions on the same date are fine.
+
+## Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| `proposed` | Under discussion, not yet implemented |
+| `accepted` | Agreed upon and implemented |
+| `tried` | Implemented but didn't work out |
+| `superseded` | Replaced by a later decision |
+| `deprecated` | Still in place but being phased out |
+
+## Template
+
+```markdown
+# Title
+
+**Date:** YYYY-MM-DD
+**Status:** proposed | accepted | tried | superseded | deprecated
+
+## Context
+
+Why was this decision needed?
+
+## Options Considered
+
+### Option A
+- Pros: ...
+- Cons: ...
+
+### Option B
+- Pros: ...
+- Cons: ...
+
+## Decision
+
+What was chosen and why.
+
+## Consequences
+
+- Positive outcomes
+- Accepted tradeoffs
+
+## Outcome
+
+Leave blank until there's real experience to report.
+What actually happened? Lessons learned? Would you choose the same again?
+```
+
+## Index
+
+| Date | Decision | Status |
+|------|----------|--------|
+| 2024-03-01 | [Adopt Vue 3 for interactive components](2024-03-01-adopt-vue-3.md) | accepted |
+| 2024-01-15 | [Adopt steel-compendium-sdk for data parsing](2024-01-15-adopt-sdk.md) | accepted |
+| 2023-10-01 | [Replace Power Roll with Feature element](2023-10-01-power-roll-to-feature.md) | accepted |
+| 2023-06-01 | [Use esbuild as bundler](2023-06-01-esbuild-bundler.md) | accepted |
+| 2023-06-01 | [Reading mode only -- no Live Preview](2023-06-01-reading-mode-only.md) | accepted |

--- a/.repo-docs/development.md
+++ b/.repo-docs/development.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Development
 
 ## Prerequisites

--- a/.repo-docs/development.md
+++ b/.repo-docs/development.md
@@ -1,0 +1,98 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Development
+
+## Prerequisites
+
+| Tool | Version | Source |
+|------|---------|--------|
+| Node.js | >= 22.15 | `package.json` engines field |
+| npm | (bundled with Node) | |
+| Obsidian | >= 0.15.0 | `manifest.json` minAppVersion |
+| devbox (optional) | any | For `gh` CLI and `jq` |
+
+## Setup
+
+1. Clone the repo:
+   ```sh
+   git clone https://github.com/SteelCompendium/draw-steel-elements.git
+   cd draw-steel-elements
+   ```
+
+2. Install dependencies:
+   ```sh
+   npm i
+   ```
+
+3. Start dev build (watch mode):
+   ```sh
+   npm run dev
+   ```
+
+4. Symlink or copy the repo directory into your Obsidian vault's `.obsidian/plugins/draw-steel-elements/` directory. The dev build produces `main.js` and `styles.css` in the repo root.
+
+5. Enable the plugin in Obsidian Settings > Community Plugins.
+
+## Common Workflows
+
+### Making changes
+
+1. Run `npm run dev` to start the watcher.
+2. Edit source files. esbuild rebuilds on save.
+3. In Obsidian, toggle the plugin off and on (or reload) to pick up changes.
+
+### Type checking
+
+```sh
+npm run tsc
+```
+
+Runs `vue-tsc --noEmit` which type-checks both `.ts` and `.vue` files.
+
+### Production build
+
+```sh
+npm run build
+```
+
+Runs type checking first (`vue-tsc --noEmit`), then builds minified output without sourcemaps.
+
+### Build without type check
+
+```sh
+npm run build-no-check
+```
+
+Skips `vue-tsc` and just runs esbuild in production mode. Used by the release recipe.
+
+### Adding a new element
+
+1. Create processor in `src/drawSteelAdmonition/<Name>/`
+2. Create model in `src/model/` with static `parseYaml(source: string)` method
+3. Register in `src/utils/RegisterElements.ts` with one or more `ds-*` language tags
+4. Add styles in `styles-source.css`
+5. Add user docs in `docs/`
+
+## Testing
+
+- **Framework:** Jest with ts-jest
+- **Run:** `npm test`
+- **Status:** Jest is configured but no test files exist yet. Test files should be `*.test.ts`.
+
+## Debugging
+
+- Plugin logs to the browser console. Open Obsidian's DevTools (Ctrl+Shift+I / Cmd+Option+I).
+- Look for `Draw Steel Elements:` prefixed log messages.
+- Schema validation errors are displayed inline in the rendered element container.
+- Reference resolution failures show the attempted paths in the error message.
+
+### Useful debug steps
+
+1. Open DevTools console in Obsidian.
+2. Filter for `Draw Steel` or `DSE` in console output.
+3. Check the rendered element for `.error-message` CSS class elements.
+4. For reference resolution issues, check that the target file exists at the expected path or in the compendium directory.

--- a/.repo-docs/index.md
+++ b/.repo-docs/index.md
@@ -7,7 +7,7 @@ tech:
   - Vue 3 (Composition API)
   - esbuild
   - Obsidian Plugin API
-updated: 2026-04-04
+updated: 2026-04-06
 ---
 
 # Draw Steel Elements
@@ -90,8 +90,10 @@ draw-steel-elements/
 |------|-----------|-----------|
 | **New to this repo** | This file | [project.md](project.md) |
 | **Developer** | [development.md](development.md) | [architecture.md](architecture.md), [conventions.md](conventions.md) |
-| **Architect** | [architecture.md](architecture.md) | [integration.md](integration.md) |
-| **DevOps / SRE** | [ci-cd.md](ci-cd.md) | [development.md](development.md) |
+| **Architect** | [architecture.md](architecture.md) | [integration.md](integration.md), [decisions/](decisions/) |
+| **PM / Scrum Master** | [project.md](project.md) | [integration.md](integration.md), [decisions/](decisions/) |
+| **DevOps / SRE** | [ci-cd.md](ci-cd.md) | [architecture.md](architecture.md) |
+| **QA / Tester** | [development.md](development.md) | [troubleshooting.md](troubleshooting.md) |
 
 ### Agent Roles
 
@@ -99,10 +101,13 @@ draw-steel-elements/
 |------------|-----------|-----------|
 | **Code review** | [conventions.md](conventions.md) | [architecture.md](architecture.md), [troubleshooting.md](troubleshooting.md) |
 | **Bug fix / debug** | [troubleshooting.md](troubleshooting.md) | [development.md](development.md), [architecture.md](architecture.md) |
-| **Feature implementation** | [architecture.md](architecture.md) | [conventions.md](conventions.md), [development.md](development.md) |
-| **PR review** | [conventions.md](conventions.md) | [architecture.md](architecture.md) |
-| **Dependency update** | [integration.md](integration.md) | [architecture.md](architecture.md) |
+| **Feature implementation** | [architecture.md](architecture.md) | [conventions.md](conventions.md), [development.md](development.md), [decisions/](decisions/) |
+| **Codebase migration** | [architecture.md](architecture.md) | [integration.md](integration.md), [conventions.md](conventions.md), [decisions/](decisions/) |
+| **PR review** | [conventions.md](conventions.md) | [architecture.md](architecture.md), [troubleshooting.md](troubleshooting.md) |
+| **Security audit** | [architecture.md](architecture.md) | [integration.md](integration.md), [ci-cd.md](ci-cd.md), [troubleshooting.md](troubleshooting.md) |
+| **Dependency update** | [integration.md](integration.md) | [architecture.md](architecture.md), [ci-cd.md](ci-cd.md) |
 | **Documentation** | This file | [project.md](project.md), [architecture.md](architecture.md) |
+| **CI/CD / DevOps** | [ci-cd.md](ci-cd.md) | [development.md](development.md), [integration.md](integration.md) |
 | **Onboarding / Q&A** | This file | [project.md](project.md), [development.md](development.md) |
 
 ## Current Status
@@ -115,7 +120,6 @@ draw-steel-elements/
 
 | File | Description |
 |------|-------------|
-| [index.md](index.md) | Overview, quick reference, and reading guide |
 | [project.md](project.md) | Product context, domain concepts, and glossary |
 | [architecture.md](architecture.md) | System components, data flow, and design decisions |
 | [development.md](development.md) | Setup, workflows, testing, and debugging |
@@ -123,3 +127,4 @@ draw-steel-elements/
 | [ci-cd.md](ci-cd.md) | CI pipeline, release process, and branch strategy |
 | [conventions.md](conventions.md) | Code style, naming, and commit conventions |
 | [troubleshooting.md](troubleshooting.md) | Known issues, common errors, and prohibitions |
+| [decisions/](decisions/) | Architecture decision records and project decision log |

--- a/.repo-docs/index.md
+++ b/.repo-docs/index.md
@@ -1,0 +1,125 @@
+---
+repo: draw-steel-elements
+type: tool
+status: active
+tech:
+  - TypeScript
+  - Vue 3 (Composition API)
+  - esbuild
+  - Obsidian Plugin API
+updated: 2026-04-04
+---
+
+# Draw Steel Elements
+
+An Obsidian plugin that renders Draw Steel TTRPG (by MCDM Productions) content as interactive, styled elements inside Obsidian notes. Users write YAML inside fenced code blocks (e.g. ` ```ds-feature `) and the plugin renders them as rich UI components: statblocks, initiative trackers, negotiation trackers, ability cards, skill lists, and more.
+
+**This repo is not:** a data source for Draw Steel content (that lives in `data-md-dse`), the SDK for parsing Draw Steel data models (that lives in `data-sdk-npm`), or the compendium website (that lives in `steelCompendium.github.io`).
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Install dependencies | `npm i` |
+| Run locally (watch mode) | `npm run dev` |
+| Run tests | `npm test` |
+| Build for production | `npm run build` |
+| Type check only | `npm run tsc` |
+| Prepare release | `just release <version>` |
+
+| Resource | URL |
+|----------|-----|
+| Docs site | https://steelcompendium.io |
+| Issue tracker | https://github.com/SteelCompendium/draw-steel-elements/issues |
+| Bug report form | https://docs.google.com/forms/d/e/1FAIpQLSc6m-pZ0NLt2EArE-Tcxr-XbAPMyhu40ANHJKtyRvvwBd2LSw/viewform |
+| GitHub | https://github.com/SteelCompendium/draw-steel-elements |
+
+## Repo Structure
+
+```
+draw-steel-elements/
+├── main.ts                          # Plugin entry point (extends Obsidian Plugin)
+├── esbuild.config.mjs               # Build config with Vue and YAML plugins
+├── manifest.json                    # Obsidian plugin manifest
+├── styles-source.css                # All plugin CSS (copied to styles.css on build)
+├── justfile                         # Release automation recipes
+├── mkdocs.yml                       # Docs site config (deployed to gh-pages)
+├── docs/                            # User-facing documentation (MkDocs source)
+│   ├── Media/                       # Screenshots and images
+│   └── *.md                         # Element-specific docs
+├── src/
+│   ├── drawSteelAdmonition/         # Code block processors (one per element type)
+│   │   ├── Features/                # ds-feature / ds-ft / ds-feat
+│   │   ├── featureblock/            # ds-featureblock / ds-fb
+│   │   ├── statblock/               # ds-statblock / ds-sb
+│   │   ├── negotiation/             # ds-negotiation / ds-nt
+│   │   ├── Characteristics/         # ds-characteristics / ds-char
+│   │   ├── Counter/                 # ds-counter / ds-ct
+│   │   ├── Skills/                  # ds-skills
+│   │   ├── StaminaBar/              # ds-stamina-bar / ds-stamina / ds-stam
+│   │   ├── ValuesRow/               # ds-values-row / ds-vr
+│   │   ├── Common/                  # Shared views (headers, horizontal rules)
+│   │   ├── initiativeProcessor.ts   # ds-initiative / ds-init / ds-it
+│   │   └── EncounterData.ts         # Runtime encounter state
+│   ├── drawSteelComponents/         # Vue 3 components
+│   │   ├── Common/                  # Shared UI (buttons, modals, toggles)
+│   │   ├── SkillList/               # Skill list Vue component
+│   │   ├── StaminaBar/              # Stamina bar Vue component + edit modal
+│   │   ├── HorizontalRule.vue
+│   │   ├── VerticalRule.vue
+│   │   └── Modal.vue
+│   ├── model/                       # Data models and YAML parsing
+│   │   ├── schemas/                 # JSON/YAML schemas for validation
+│   │   └── *.ts                     # TypeScript model classes
+│   ├── types/                       # Type declarations
+│   ├── utils/                       # Utilities
+│   │   ├── RegisterElements.ts      # Registers all code block processors
+│   │   ├── ComponentProcessor.ts    # Generic Vue component mounting
+│   │   ├── CompendiumDownloader.ts  # GitHub release downloader
+│   │   ├── ReferenceResolver.ts     # Cross-note reference resolution
+│   │   └── JsonSchemaValidator.ts   # AJV-based schema validation
+│   └── views/                       # Obsidian modals and settings UI
+└── .github/workflows/ci.yml         # MkDocs deployment to gh-pages
+```
+
+## Reading Guide by Role
+
+### Human Roles
+
+| Role | Start here | Then read |
+|------|-----------|-----------|
+| **New to this repo** | This file | [project.md](project.md) |
+| **Developer** | [development.md](development.md) | [architecture.md](architecture.md), [conventions.md](conventions.md) |
+| **Architect** | [architecture.md](architecture.md) | [integration.md](integration.md) |
+| **DevOps / SRE** | [ci-cd.md](ci-cd.md) | [development.md](development.md) |
+
+### Agent Roles
+
+| Agent Role | Start here | Then read |
+|------------|-----------|-----------|
+| **Code review** | [conventions.md](conventions.md) | [architecture.md](architecture.md), [troubleshooting.md](troubleshooting.md) |
+| **Bug fix / debug** | [troubleshooting.md](troubleshooting.md) | [development.md](development.md), [architecture.md](architecture.md) |
+| **Feature implementation** | [architecture.md](architecture.md) | [conventions.md](conventions.md), [development.md](development.md) |
+| **PR review** | [conventions.md](conventions.md) | [architecture.md](architecture.md) |
+| **Dependency update** | [integration.md](integration.md) | [architecture.md](architecture.md) |
+| **Documentation** | This file | [project.md](project.md), [architecture.md](architecture.md) |
+| **Onboarding / Q&A** | This file | [project.md](project.md), [development.md](development.md) |
+
+## Current Status
+
+- **Health:** active development
+- **Last significant change:** v5.1.1 -- fixed double-click opening edit mode in reading mode
+- **Known blockers:** No Live Preview mode support
+
+## Documents in This Directory
+
+| File | Description |
+|------|-------------|
+| [index.md](index.md) | Overview, quick reference, and reading guide |
+| [project.md](project.md) | Product context, domain concepts, and glossary |
+| [architecture.md](architecture.md) | System components, data flow, and design decisions |
+| [development.md](development.md) | Setup, workflows, testing, and debugging |
+| [integration.md](integration.md) | Upstream/downstream dependencies and cross-repo workflows |
+| [ci-cd.md](ci-cd.md) | CI pipeline, release process, and branch strategy |
+| [conventions.md](conventions.md) | Code style, naming, and commit conventions |
+| [troubleshooting.md](troubleshooting.md) | Known issues, common errors, and prohibitions |

--- a/.repo-docs/integration.md
+++ b/.repo-docs/integration.md
@@ -1,0 +1,96 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Integration
+
+## Dependency Map
+
+```
+steel-compendium-sdk (data-sdk-npm)
+        │
+        ▼ (bundled at build time)
+draw-steel-elements (this repo)
+        │
+        ├── reads from ──> data-md-dse (compendium content, downloaded at runtime)
+        │
+        └── runs inside ──> Obsidian (host app)
+```
+
+## Upstream Dependencies
+
+| Dependency | Type | How used |
+|-----------|------|----------|
+| `steel-compendium-sdk` (`data-sdk-npm`) | npm devDependency (bundled) | Provides TypeScript model classes and YAML parsing for Draw Steel data structures. Used by model classes in `src/model/`. Version changes can be breaking (v4.0.0 required compendium re-download). |
+| `data-md-dse` | Runtime data (GitHub releases) | Markdown files with Draw Steel reference content. Downloaded as `repo.zip` from GitHub releases via `CompendiumDownloader`. Not a build dependency. |
+| Obsidian Plugin API | Runtime host | Provides `Plugin`, `App`, `Vault`, `parseYaml`, `MarkdownPostProcessorContext`, modal APIs. Externalized in esbuild config. |
+
+## Downstream Dependents
+
+None. This is an end-user Obsidian plugin. No other repos import or depend on it.
+
+## API Surface
+
+This plugin exposes no programmatic API. Its interface is the set of code block language tags:
+
+| Language tag(s) | Element |
+|----------------|---------|
+| `ds-ft`, `ds-feat`, `ds-feature` | Feature (ability/power roll) |
+| `ds-fb`, `ds-featureblock` | Featureblock (grouped features with stats) |
+| `ds-sb`, `ds-statblock` | Statblock (creature/NPC) |
+| `ds-it`, `ds-init`, `ds-initiative`, `ds-initiative-tracker` | Initiative tracker |
+| `ds-nt`, `ds-negotiation`, `ds-negotiation-tracker` | Negotiation tracker |
+| `ds-stam`, `ds-stamina`, `ds-stamina-bar` | Stamina bar |
+| `ds-ct`, `ds-counter` | Counter |
+| `ds-char`, `ds-characteristics` | Characteristics |
+| `ds-skills` | Skill list |
+| `ds-vr`, `ds-value-row`, `ds-values-row` | Values row |
+| `ds-hr`, `ds-horizontal-rule` | Horizontal rule |
+
+Users interact by writing YAML inside these fenced code blocks in Obsidian notes.
+
+## Data Contracts
+
+### Element YAML format
+
+Each element type expects YAML conforming to its model class. Schemas in `src/model/schemas/` define the expected structure for validated elements. Unvalidated elements rely on the model's `parseYaml()` method to extract fields.
+
+### Reference syntax
+
+Elements can reference content in other notes:
+- `@path/to/note` -- resolve by vault path
+- `[[Note Name]]` -- resolve by Obsidian wikilink
+
+The `ReferenceResolver` searches: exact path, path + `.md`, compendium directory prefix, then Obsidian metadata cache.
+
+### Compendium release format
+
+The `CompendiumDownloader` expects a GitHub release with a `repo.zip` asset containing markdown files. The zip is extracted into the configured destination directory (default: `DS Compendium`).
+
+## Cross-Repo Workflows
+
+### SDK version bump
+
+1. New version of `steel-compendium-sdk` is published to npm.
+2. In this repo: `npm install steel-compendium-sdk@<version>`.
+3. Update model classes if schemas changed.
+4. Rebuild and test with existing compendium content.
+5. If breaking: bump major version, update CHANGELOG, note that users must re-download compendium.
+
+### Compendium content update
+
+1. New content is added/updated in `data-md-dse` and a release is created.
+2. Users run the "Download Compendium" command in Obsidian to fetch the latest release.
+3. No code changes needed in this repo unless the content format changed.
+
+## Integration Testing
+
+No automated integration tests exist. Manual testing:
+
+1. Install the plugin in a test vault.
+2. Create notes with various `ds-*` code blocks.
+3. Download the compendium and verify rendering.
+4. Test reference resolution across notes.
+5. Test initiative tracker interactivity (adding/removing creatures, conditions, stamina changes).

--- a/.repo-docs/integration.md
+++ b/.repo-docs/integration.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Integration
 
 ## Dependency Map

--- a/.repo-docs/project.md
+++ b/.repo-docs/project.md
@@ -1,0 +1,95 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Project Context
+
+## Product Overview
+
+Draw Steel Elements is an Obsidian community plugin that brings Draw Steel TTRPG content to life inside Obsidian vaults. Players and GMs write YAML inside fenced code blocks and the plugin renders styled, interactive elements: ability cards with power rolls, creature statblocks, initiative trackers for combat, negotiation trackers, stamina bars, and more. The plugin also includes a compendium downloader that fetches pre-built Draw Steel reference content from GitHub releases directly into the vault.
+
+The problem it solves: Draw Steel content is complex and structured (abilities have tiers, creatures have stats, encounters have initiative order). Plain markdown can't express this well. This plugin provides first-class rendering and interaction for Draw Steel game mechanics inside the note-taking tool many TTRPG players already use.
+
+## Domain Context
+
+This is a TTRPG (tabletop role-playing game) tool. The mental models needed:
+
+- **Draw Steel** is a tactical TTRPG by MCDM Productions. It uses Power Rolls (2d10 + modifier) with three tier outcomes, hero characteristics (Might, Agility, Reason, Intuition, Presence), and structured combat with initiative, stamina, and conditions.
+- **Obsidian** is a note-taking app that renders markdown. Plugins extend it by registering code block processors that intercept fenced code blocks and render custom HTML/DOM.
+- **Code block processors** are the core extension mechanism. A block like ` ```ds-feature ` triggers the plugin's FeatureProcessor, which parses the YAML content and renders styled HTML.
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Element** | A rendered UI component produced from a `ds-*` code block. The plugin registers multiple elements (feature, statblock, initiative, etc.) |
+| **Processor** | TypeScript class that handles parsing YAML and rendering DOM for a specific element type. Each has a `handler` method registered with Obsidian. |
+| **Feature** | A Draw Steel ability, test, resistance roll, or other power-roll-based game mechanic. Rendered with tier outcomes (11 or lower, 12-16, 17+). |
+| **Featureblock** | A grouped collection of features with stats, used for class kits or ancestry features. |
+| **Statblock** | A creature or NPC stat block showing characteristics, abilities, stamina, and other combat stats. |
+| **Initiative Tracker** | Interactive encounter manager for combat. Tracks turn order, stamina, conditions, and supports referencing statblocks from other notes. |
+| **Negotiation Tracker** | Interactive tracker for Draw Steel's negotiation subsystem. Tracks patience, interest, motivations, pitfalls, and arguments. |
+| **Stamina Bar** | Visual health bar component showing current/max stamina with temporary stamina support. |
+| **Power Roll** | Draw Steel's core dice mechanic: 2d10 + modifier with three tier outcomes. |
+| **Compendium** | A downloadable set of pre-built markdown notes with Draw Steel reference content (from `data-md-dse` repo). |
+| **Reference Resolution** | The ability to reference content from other notes using `@path` or `[[wikilink]]` syntax within element YAML. |
+| **ComponentWrapper** | A JSON schema-validated wrapper format that standardizes how Vue components receive data. |
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| `ds-*` | Prefix for all plugin code block languages (e.g., `ds-ft`, `ds-sb`, `ds-it`) |
+| DSE | Draw Steel Elements (this plugin) |
+| SCC | Steel Compendium Classification -- hierarchical ID system (`source:type:item`) used across data repos |
+| SDK | `steel-compendium-sdk` / `data-sdk-npm` -- TypeScript library for parsing Draw Steel data models |
+| Tier | Power roll outcome bracket: Tier 1 (11-), Tier 2 (12-16), Tier 3 (17+) |
+| Stamina | Draw Steel's health system (not HP). Creatures have max stamina and can gain temporary stamina. |
+| Condition | Status effects in Draw Steel (bleeding, dazed, frightened, etc.) applied during combat |
+| Vault | An Obsidian workspace directory containing markdown notes |
+| Minion | A weak creature type in Draw Steel that shares a stamina pool with other minions |
+
+## Audiences
+
+| Audience | How they use it |
+|----------|-----------------|
+| **Draw Steel GMs** | Run encounters using initiative tracker, display statblocks, reference compendium content |
+| **Draw Steel Players** | View ability cards, track character stamina, reference skills |
+| **Plugin Developers** | Extend or contribute to the plugin codebase |
+| **Compendium Authors** | Create Draw Steel content in markdown that leverages the plugin's rendering |
+
+## Feature Inventory
+
+### Shipped
+
+- Feature element (`ds-feature`, `ds-feat`, `ds-ft`) -- ability/power roll rendering with tier outcomes
+- Featureblock element (`ds-featureblock`, `ds-fb`) -- grouped features with stats
+- Statblock element (`ds-statblock`, `ds-sb`) -- creature/NPC stat blocks
+- Initiative tracker (`ds-initiative`, `ds-init`, `ds-it`) -- interactive combat tracker with conditions, stamina, minion pools
+- Negotiation tracker (`ds-negotiation`, `ds-nt`) -- interactive negotiation subsystem tracker
+- Stamina bar (`ds-stamina-bar`, `ds-stamina`, `ds-stam`) -- visual health bar with temp stamina
+- Characteristics element (`ds-characteristics`, `ds-char`) -- hero stat display
+- Counter element (`ds-counter`, `ds-ct`) -- generic counter
+- Skills element (`ds-skills`) -- skill list with collapsible groups
+- Values row (`ds-values-row`, `ds-vr`) -- key-value display row
+- Horizontal rule (`ds-hr`, `ds-horizontal-rule`) -- Draw Steel styled divider
+- Compendium downloader -- fetches `data-md-dse` releases into vault
+- Cross-note reference resolution (`@path` and `[[wikilink]]` syntax)
+- JSON Schema validation (AJV) for element YAML
+- Vue 3 component system with Composition API
+- Mobile support
+
+### Known Limitations
+
+- No Live Preview mode support (Reading mode only)
+- No dice rolling integration
+- No party tracker (XP, Victories)
+
+## Constraints and Risks
+
+- **Obsidian API dependency**: Plugin is tightly coupled to Obsidian's `Plugin`, `MarkdownPostProcessorContext`, and vault APIs. API changes in Obsidian can break functionality.
+- **SDK dependency**: The `steel-compendium-sdk` (v2.1.5) defines data model schemas. Major SDK version bumps are breaking changes (as seen in v4.0.0).
+- **No test suite**: The repo has jest configured but no test files exist. This is a risk for regressions.
+- **Licensing**: Published under MIT. Content is under the DRAW STEEL Creator License and is not affiliated with MCDM Productions.

--- a/.repo-docs/project.md
+++ b/.repo-docs/project.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Project Context
 
 ## Product Overview

--- a/.repo-docs/troubleshooting.md
+++ b/.repo-docs/troubleshooting.md
@@ -1,9 +1,3 @@
----
-repo: draw-steel-elements
-type: tool
-updated: 2026-04-04
----
-
 # Troubleshooting
 
 ## Do NOT

--- a/.repo-docs/troubleshooting.md
+++ b/.repo-docs/troubleshooting.md
@@ -1,0 +1,56 @@
+---
+repo: draw-steel-elements
+type: tool
+updated: 2026-04-04
+---
+
+# Troubleshooting
+
+## Do NOT
+
+- **Do not use Live Preview mode.** The plugin only renders in Reading mode. Live Preview uses a different CodeMirror 6 rendering pipeline that the plugin does not support.
+- **Do not store homebrew content in the compendium download directory.** The `CompendiumDownloader` deletes the entire destination directory before extracting a new release. Default directory: `DS Compendium`.
+- **Do not use the `v` prefix in version tags.** The manifest, package.json, and GitHub release tags all use bare semver (e.g., `5.1.1`).
+- **Do not register schemas that are validated directly** in `initializeSchemas()`. Only register dependency schemas that other schemas reference via `$ref`.
+
+## Known Issues
+
+- **No Live Preview support** -- Elements only render in Reading mode. This is the primary known limitation.
+- **Double-click to edit** -- Fixed in v5.1.1. Previously, double-clicking a rendered element in Reading mode would switch to edit mode.
+- **Compendium re-download required on breaking SDK updates** -- When the SDK version has breaking changes, users must re-download the compendium. The old compendium directory is deleted.
+
+## Common Errors
+
+### "Reference file (path) not found"
+
+**Cause:** The `@path` or `[[wikilink]]` reference in element YAML points to a file that doesn't exist.
+
+**Fix:** Check that:
+1. The file exists at the exact path specified
+2. The file exists in the compendium directory (`DS Compendium/` by default)
+3. The file name matches (case-sensitive on some platforms)
+4. The `.md` extension is included or the file is discoverable without it
+
+### "No Draw Steel Elements code block (ds-*) found in [file]"
+
+**Cause:** A reference points to a note, but that note doesn't contain any `ds-*` code block.
+
+**Fix:** Ensure the referenced note contains a fenced code block with a `ds-*` language tag.
+
+### "DSE Release asset 'repo.zip' not found"
+
+**Cause:** The GitHub release for `data-md-dse` doesn't have a `repo.zip` asset attached.
+
+**Fix:** Check the release on GitHub. The compendium downloader specifically looks for an asset named `repo.zip`.
+
+### Schema validation errors displayed inline
+
+**Cause:** The YAML in a code block doesn't conform to the expected schema.
+
+**Fix:** Check the element's documentation in `docs/` for the expected YAML structure. The error message shows the validation path and issue.
+
+### Plugin fails to load a component
+
+**Cause:** YAML parsing error or model constructor error.
+
+**Fix:** The error is displayed inline with the message prefix "The Draw Steel Elements plugin failed to load the [Component Name]". Check the YAML syntax and required fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Draw Steel Elements
+
+Obsidian plugin that renders Draw Steel TTRPG content as interactive, styled elements.
+Users write YAML in `ds-*` fenced code blocks and the plugin renders ability cards,
+statblocks, initiative trackers, negotiation trackers, stamina bars, and more.
+
+## Repository Documentation
+
+This repo uses standardized `.repo-docs/` documentation. **Read `.repo-docs/index.md`
+first** -- it contains the reading guide, role-based routing, and links to all other docs.
+
+## Quick Start
+
+- `npm i` -- install dependencies
+- `npm run dev` -- build with watch mode
+- `npm run build` -- production build (type check + minified)
+- `npm test` -- run tests (Jest, currently no test files)
+
+## Key Architecture
+
+- **Processor pattern**: Each `ds-*` element has a processor in `src/drawSteelAdmonition/`
+- **Two rendering strategies**: DOM manipulation (most elements) and Vue 3 (interactive elements)
+- **Models**: `src/model/` with `parseYaml()` static methods and AJV schema validation
+- **Vue components**: `src/drawSteelComponents/` using Composition API
+- **SDK**: `steel-compendium-sdk` bundled at build time for data model parsing
+
+## Important Constraints
+
+- **Reading mode only** -- no Live Preview support
+- Output must be CJS format for Obsidian
+- Target ES2018
+- `obsidian`, `electron`, and CodeMirror packages are external (host-provided)
+- Compendium downloader deletes the destination directory before extracting -- don't store homebrew there


### PR DESCRIPTION
## Summary

- Adds standardized `.repo-docs/` directory with 7 documentation files covering project context, architecture, development setup, integration points, CI/CD, conventions, and troubleshooting
- Classified as a **tool** repo (Obsidian plugin with TypeScript + Vue 3)
- All content derived from codebase analysis — no placeholders or aspirational claims

## Files

| File | Description |
|------|-------------|
| `index.md` | Overview, quick reference, repo structure, reading guide |
| `project.md` | Domain context, Draw Steel glossary, feature inventory |
| `architecture.md` | System components, data flow, design decisions, extension points |
| `development.md` | Setup, workflows, testing, debugging |
| `integration.md` | SDK/compendium dependency map, cross-repo workflows |
| `ci-cd.md` | MkDocs CI, release process via justfile, versioning |
| `conventions.md` | Naming, code style, ESLint config, commit patterns |
| `troubleshooting.md` | Known issues, common errors, prohibitions |

## Test plan

- [ ] Verify all file paths and commands referenced in docs are accurate
- [ ] Confirm reading guides point to existing files
- [ ] Review domain glossary for accuracy against Draw Steel rules